### PR TITLE
Hide player text if player is empty

### DIFF
--- a/templates/default/entity/Watching.tpl.php
+++ b/templates/default/entity/Watching.tpl.php
@@ -48,8 +48,15 @@
             </div>
             <div class="e-content">
                 <?= $this->__(['value' => $vars['object']->body, 'object' => $vars['object']])->draw('forms/output/richtext'); ?>
-                
+
+                <?php
+                if (!empty($vars['object']->getPlayer())) {
+                ?>
                 <p style="font-style: italic; text-align: right;">Watched on <?= $vars['object']->getPlayer() ?></p>
+                <?php
+                }
+                ?>                
+
             </div>
             
             <div style="display: none;">


### PR DESCRIPTION
I sometimes leave Player blank and this prevents the template from showing "Watched on " with nothing for Player.